### PR TITLE
feat: синхронизация настроек плагинов с поддержкой профилей Lampa

### DIFF
--- a/app/api/plugin_settings.py
+++ b/app/api/plugin_settings.py
@@ -1,9 +1,12 @@
 """
 Синхронизация настроек плагинов Lampa между устройствами одного пользователя.
 
-GET  /api/plugin-settings?token=&plugin=   — получить все настройки плагина
-PATCH /api/plugin-settings?token=&plugin=  — обновить один ключ {key, value}
-WS   /api/plugin-settings/ws?token=        — real-time канал обновлений
+GET  /api/plugin-settings?token=&plugin=&lampa_profile_id=  — получить настройки профиля
+PATCH /api/plugin-settings?token=&plugin=&lampa_profile_id= — обновить один ключ {key, value}
+WS   /api/plugin-settings/ws?token=                        — real-time канал обновлений
+
+lampa_profile_id по умолчанию '' — настройки без профиля.
+WS-сообщения включают lampa_profile_id, клиент применяет только совпадающий профиль.
 """
 import json
 import logging
@@ -28,24 +31,34 @@ router = APIRouter()
 _connections: Dict[int, Set[WebSocket]] = defaultdict(set)
 
 
-async def _get_or_create(db: AsyncSession, user_id: int, plugin: str) -> PluginSettings:
+async def _get_or_create(
+    db: AsyncSession, user_id: int, lampa_profile_id: str, plugin: str
+) -> PluginSettings:
     result = await db.execute(
         select(PluginSettings).where(
             PluginSettings.user_id == user_id,
+            PluginSettings.lampa_profile_id == lampa_profile_id,
             PluginSettings.plugin == plugin,
         )
     )
     row = result.scalar_one_or_none()
     if row is None:
-        row = PluginSettings(user_id=user_id, plugin=plugin, settings="{}")
+        row = PluginSettings(
+            user_id=user_id,
+            lampa_profile_id=lampa_profile_id,
+            plugin=plugin,
+            settings="{}",
+        )
         db.add(row)
         await db.flush()
     return row
 
 
-async def _broadcast(user_id: int, plugin: str, key: str, value) -> None:
-    """Отправить обновление всем подключённым устройствам пользователя."""
-    msg = json.dumps({"plugin": plugin, "key": key, "value": value})
+async def _broadcast(user_id: int, plugin: str, lampa_profile_id: str, key: str, value) -> None:
+    """Отправить обновление всем подключённым устройствам пользователя.
+    Клиент применяет только если lampa_profile_id совпадает с текущим профилем.
+    """
+    msg = json.dumps({"plugin": plugin, "lampa_profile_id": lampa_profile_id, "key": key, "value": value})
     dead = set()
     for ws in list(_connections.get(user_id, set())):
         try:
@@ -56,19 +69,20 @@ async def _broadcast(user_id: int, plugin: str, key: str, value) -> None:
 
 
 # ---------------------------------------------------------------------------
-# GET — получить настройки плагина
+# GET — получить настройки плагина для профиля
 # ---------------------------------------------------------------------------
 
 @router.get("/api/plugin-settings")
 async def get_plugin_settings(
     plugin: str = Query(..., min_length=1, max_length=100),
+    lampa_profile_id: str = Query(default="", max_length=100),
     device: Device = Depends(get_device_by_token),
     db: AsyncSession = Depends(get_db),
 ):
     if not device:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-    row = await _get_or_create(db, device.user_id, plugin)
+    row = await _get_or_create(db, device.user_id, lampa_profile_id, plugin)
     await db.commit()
 
     try:
@@ -92,6 +106,7 @@ class PatchBody(BaseModel):
 async def patch_plugin_settings(
     body: PatchBody,
     plugin: str = Query(..., min_length=1, max_length=100),
+    lampa_profile_id: str = Query(default="", max_length=100),
     device: Device = Depends(get_device_by_token),
     db: AsyncSession = Depends(get_db),
 ):
@@ -100,7 +115,7 @@ async def patch_plugin_settings(
     if not body.key:
         raise HTTPException(status_code=400, detail="key required")
 
-    row = await _get_or_create(db, device.user_id, plugin)
+    row = await _get_or_create(db, device.user_id, lampa_profile_id, plugin)
 
     try:
         data = json.loads(row.settings)
@@ -111,7 +126,7 @@ async def patch_plugin_settings(
     row.settings = json.dumps(data, ensure_ascii=False)
     await db.commit()
 
-    await _broadcast(device.user_id, plugin, body.key, body.value)
+    await _broadcast(device.user_id, plugin, lampa_profile_id, body.key, body.value)
 
     return {"ok": True}
 
@@ -146,7 +161,6 @@ async def plugin_settings_ws(
 
     try:
         while True:
-            # Держим соединение открытым, входящие сообщения игнорируем
             await websocket.receive_text()
     except WebSocketDisconnect:
         pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -402,17 +402,22 @@ class Totp2faPending(Base):
 
 
 class PluginSettings(Base):
-    """Настройки плагинов Lampa — синхронизируются между устройствами одного пользователя."""
+    """Настройки плагинов Lampa — синхронизируются между устройствами одного пользователя.
+
+    Изоляция по профилю: каждая комбинация (user_id, lampa_profile_id, plugin) — отдельная строка.
+    lampa_profile_id = '' означает «без профиля».
+    """
 
     __tablename__ = "plugin_settings"
 
-    user_id    = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, primary_key=True)
-    plugin     = Column(String(100), nullable=False, primary_key=True)
-    settings   = Column(Text, nullable=False, default="{}", server_default="'{}'")
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    user_id          = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, primary_key=True)
+    lampa_profile_id = Column(String(100), nullable=False, default="", server_default="''", primary_key=True)
+    plugin           = Column(String(100), nullable=False, primary_key=True)
+    settings         = Column(Text, nullable=False, default="{}", server_default="'{}'")
+    updated_at       = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<PluginSettings(user_id={self.user_id}, plugin={self.plugin})>"
+        return f"<PluginSettings(user_id={self.user_id}, lampa_profile_id={self.lampa_profile_id!r}, plugin={self.plugin})>"
 
 
 

--- a/migrations/migrate_plugin_settings_profile.py
+++ b/migrations/migrate_plugin_settings_profile.py
@@ -1,0 +1,44 @@
+"""
+Миграция: добавляем lampa_profile_id в plugin_settings.
+
+Очищает таблицу (конфликтующие данные без профиля) и пересоздаёт
+с новым составным PK (user_id, lampa_profile_id, plugin).
+
+Запуск:
+    poetry run python migrations/migrate_plugin_settings_profile.py
+    docker compose exec app poetry run python migrations/migrate_plugin_settings_profile.py
+"""
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text
+from app.db.database import engine, init_db
+
+
+async def main():
+    async with engine.begin() as conn:
+        col_exists = await conn.execute(text("""
+            SELECT EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'plugin_settings'
+                  AND column_name = 'lampa_profile_id'
+            )
+        """))
+        if col_exists.scalar():
+            print("ℹ️  lampa_profile_id уже существует — миграция не нужна")
+            return
+
+        print("🗑️  Очищаем plugin_settings (данные без профиля несовместимы)...")
+        await conn.execute(text("DROP TABLE IF EXISTS plugin_settings"))
+        print("✅ Таблица удалена")
+
+    await init_db()
+    print("✅ Таблица plugin_settings пересоздана с lampa_profile_id")
+    print("\n✅ Миграция завершена")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
🔄 Модель PluginSettings: добавлено поле lampa_profile_id для хранения настроек на уровне профиля 🔧 Функции:
_get_or_create(): теперь принимает lampa_profile_id, создаёт запись с пустым профилем ("") по умолчанию _broadcast(): включает lampa_profile_id в сообщение — клиент применяет обновление только при совпадении профиля 🌐 API эндпоинты:
GET /api/plugin-settings: новый параметр lampa_profile_id (по умолчанию "") PATCH /api/plugin-settings: обновление ключа с учётом профиля WS /api/plugin-settings/ws: real-time рассылка с lampa_profile_id в полезной нагрузке 👥 Изоляция настроек: настройки без профиля (lampa_profile_id == "") и с профилем хранятся раздельно 📱 Клиентская логика: устройство применяет обновление только если lampa_profile_id в сообщении совпадает с текущим профилем