### PR TITLE
fix: не прерывать поиск по MyShows при пустом ответе каталога

### DIFF
--- a/app/api/episodes.py
+++ b/app/api/episodes.py
@@ -122,11 +122,8 @@ async def find_myshows_show(mc: MediaCard, client: httpx.AsyncClient, title_en: 
         params["search"]["year"] = int(year)
 
     result = await _ms_rpc(client, "shows.GetCatalog", params)
-    if not result:
-        return None
-
     shows = []
-    for item in result:
+    for item in (result or []):
         show = item.get("show") if isinstance(item, dict) and "show" in item else item
         if show and isinstance(show, dict):
             shows.append(show)


### PR DESCRIPTION
  Если shows.GetCatalog по original_title вернул пустой список
  (например, японская кириллица ワンピース), раньше сразу return None —
  поиск по русскому названию никогда не достигался.
  Теперь продолжаем и пробуем catalog_ru (mc.title).